### PR TITLE
Add pycodestyle scripts to obs-monitor

### DIFF
--- a/.github/workflows/norms.yaml
+++ b/.github/workflows/norms.yaml
@@ -1,5 +1,5 @@
 name: Coding Norms
-on: [push]
+on: [push, pull_request]
 
 jobs:
   check_pynorms:

--- a/.github/workflows/norms.yaml
+++ b/.github/workflows/norms.yaml
@@ -20,4 +20,4 @@ jobs:
     - name: Run pycodestyle
       run: |
         cd $GITHUB_WORKSPACE/obs-monitor
-        pycodestyle -v --config ./.pycodestyle ./ush ./ush/plotObsMon
+        pycodestyle -v --config ./.pycodestyle ./ush

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,29 @@
+---
+
+extends: default
+
+rules:
+  braces:
+    level: warning
+    max-spaces-inside: 1
+  brackets:
+    level: warning
+    max-spaces-inside: 1
+  colons:
+    level: warning
+  commas:
+    level: warning
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines:
+    level: warning
+  hyphens:
+    level: warning
+  indentation:
+    level: warning
+    indent-sequences: consistent
+  line-length:
+    level: warning
+    allow-non-breakable-inline-mappings: true
+  truthy: disable

--- a/pycodestyle.cfg
+++ b/pycodestyle.cfg
@@ -1,0 +1,10 @@
+# (C) Copyright 2021-2022 United States Government as represented by the Administrator of the
+# National Aeronautics and Space Administration. All Rights Reserved.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+[pycodestyle]
+max-line-length = 100
+indent-size = 4
+statistics = True

--- a/pycodestyle.cfg
+++ b/pycodestyle.cfg
@@ -1,6 +1,3 @@
-# (C) Copyright 2021-2022 United States Government as represented by the Administrator of the
-# National Aeronautics and Space Administration. All Rights Reserved.
-#
 # This software is licensed under the terms of the Apache Licence Version 2.0
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
 

--- a/pycodestyle_run.py
+++ b/pycodestyle_run.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 
-# (C) Copyright 2021-2022 United States Government as represented by the Administrator of the
-# National Aeronautics and Space Administration. All Rights Reserved.
-#
 # This software is licensed under the terms of the Apache Licence Version 2.0
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
 

--- a/pycodestyle_run.py
+++ b/pycodestyle_run.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+
+# (C) Copyright 2021-2022 United States Government as represented by the Administrator of the
+# National Aeronautics and Space Administration. All Rights Reserved.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+import unittest
+import pycodestyle
+
+
+# --------------------------------------------------------------------------------------------------
+
+
+class TestCodeFormat(unittest.TestCase):
+
+    def test_conformance(self):
+        """Test that we conform to PEP-8."""
+        style = pycodestyle.StyleGuide(config_file='pycodestyle.cfg')
+        result = style.check_files(['.'])
+        self.assertEqual(result.total_errors, 0, "Found code style errors (and warnings).")
+
+
+# --------------------------------------------------------------------------------------------------
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/ush/plotObsMon.py
+++ b/ush/plotObsMon.py
@@ -138,7 +138,8 @@ if __name__ == "__main__":
             instrument = inst.get('name')
 
             for plot in inst.get('plot_list'):
-                config = loadConfig(satname, instrument, plot, cycle_tm, cycle_interval, data_location)
+                config = loadConfig(satname, instrument, plot, cycle_tm,
+                                    cycle_interval, data_location)
                 plot_template = f"{config['PLOT_TEMPLATE']}.yaml"
                 plot_yaml = f"{config['SENSOR']}_{config['SAT']}_{plot_template}"
 


### PR DESCRIPTION
Added `pycodestyle_run.py` and related files (lifted from eva).  Renamed `plotObsMon `to `plotObsMon.py` so pycodestyle_run.py could pick it up.

Resolves #10 