### PR TITLE
Add input yaml file as argument to runObsMon.sh

### DIFF
--- a/driver/runObsMon.sh
+++ b/driver/runObsMon.sh
@@ -10,11 +10,13 @@
 #  usage
 #--------------------------------------------------------------------
 function usage {
-  echo "Usage:  runObsMon.sh -p|--pdate pdate -m|--model, [-r|--run]"
-  echo "            -p | --pdate 	cycle time to be processed, format yyyymmddhh"
-  echo "              			if unspecified the last available date will be processed"
-  echo "            -m | --model	model or experiment name (i.e. gfs, nam)"
-  echo "	    -r | --run		optional, name of run (i.e. gfs, gdas)"
+  echo "Usage:  runObsMon.sh -p|--pdate pdate -m|--model, [-y|--yaml]"
+  echo "            -p | --pdate 	cycle time to be processed, format yyyymmddhh."
+  echo "              			If unspecified the last available date will be processed."
+  echo "            -m | --model	model or experiment name (i.e. gfs, exp1, etc.)"
+  echo "            -y | --yaml 	yaml plot file, with full or relative path."
+  echo "                                If no yaml file is specified the default is "
+  echo "                                parm/[model]/[model]_plot.yaml"
   echo " "
 }
 
@@ -35,7 +37,7 @@ fi
 
 pdate=""
 model=""
-run=""
+yaml_file=""
 
 while [[ $# -ge 1 ]]
 do
@@ -51,8 +53,8 @@ do
          model="$2"
          shift # past argument
       ;;
-      -r|--run)
-         run="$2"
+      -y|--yaml)
+         yaml_file="$2"
          shift # past argument
       ;;
    esac
@@ -62,13 +64,21 @@ done
 
 echo pdate: $pdate
 echo model: $model
-echo run:   $run
+
+if [ -n "${yaml_file}" ]; then 
+   if  [ ! -e ${yaml_file} ]; then
+      echo "ERROR:  input yaml file ${yaml_file} not found"
+      exit 1 
+   fi
+   yaml_file=`realpath ${yaml_file}`
+fi
+echo yaml_file:  $yaml_file
 
 export PDY=`echo ${pdate}|cut -c1-8`
 export cyc=`echo ${pdate}|cut -c9-10`
 export NET=obsmon
 export MODEL=${model}
-export RUN=${run}
+export YAML_FILE=${yaml_file}
 export KEEPDATA="YES"
 
 #--------------------------------
@@ -106,7 +116,7 @@ case ${MACHINE_ID} in
 	   -v "PYTHONPATH=${PYTHONPATH}, PATH=${PATH}, HOMEobsmon=${HOMEobsmon}, COMOUT=${COMOUT}, \
 	       MODEL=${MODEL}, PDY=${PDY}, cyc=${cyc}, DATAROOT=${DATAROOT}, APRUN_PY=${APRUN_PY}, \
 	       MACHINE_ID=${MACHINE_ID}, ACCOUNT=${ACCOUNT}, JOB_QUEUE=${JOB_QUEUE}, SUB=${SUB},
-	       OM_LOGS=${OM_LOGS}" \
+	       OM_LOGS=${OM_LOGS}, YAML_FILE=${YAML_FILE}" \
            -l select=1:mem=500mb -l walltime=0:05:00 -N ${jobname} ${jobfile}
       ;;
 esac

--- a/scripts/exobsmon_plot.sh
+++ b/scripts/exobsmon_plot.sh
@@ -5,12 +5,11 @@
 #------------------
 
 #-------------------------------------------------------------
-# locate $model_plots.yaml and instrument_channels.yaml files
+# locate yaml_file and instrument_channels.yaml files
 #-------------------------------------------------------------
-
-plot_yaml=${plot_yaml:-${PARMobsmon}/${MODEL}/${MODEL}_plots.yaml}
-if [[ ! -e ${plot_yaml} ]]; then
-   echo "ERROR:  yaml plot file ${plot_yaml} NOT FOUND"
+yaml_file=${YAML_FILE:-${PARMobsmon}/${MODEL}/${MODEL}_plots.yaml}
+if [[ ! -e ${yaml_file} ]]; then
+   echo "ERROR:  yaml plot file ${yaml_file} NOT FOUND"
    exit 1
 fi
 
@@ -21,10 +20,10 @@ if [[ ! -e ${chan_yaml} ]]; then
 fi
 
 #---------------------------------------------------------------
-# split $plot_yaml into sat/instr[/plot], minimization, and obs
+# split $yaml_file into sat/instr[/plot], minimization, and obs
 # in order to reduce the plot jobs to a more managable size 
 #
-${APRUN_PY} ${USHobsmon}/splitPlotYaml.py -i ${plot_yaml} -c ${chan_yaml}
+${APRUN_PY} ${USHobsmon}/splitPlotYaml.py -i ${yaml_file} -c ${chan_yaml}
 
 #--------------------------------------------------------------
 # Submit OM_plots job if split yields any *.yaml files

--- a/ush/splitPlotYaml.py
+++ b/ush/splitPlotYaml.py
@@ -95,7 +95,7 @@ if __name__ == "__main__":
                         pd['satellites'] = [{'name': satname,
                                              'instruments': [{'name': iname,
                                                               'plot_list': [pl]}]}]
-                        fname = f'sat_{satname}_{iname}_{ctr}.yaml'
+                        fname = f'OM_PLOT_sat_{satname}_{iname}_{ctr}.yaml'
                         file = open(fname, "w")
                         yaml.dump(pd, file)
                         file.close()


### PR DESCRIPTION
Modify input arguments to `runObsMon.sh`, removing the -r|--run argument (which wasn't used), and adding -y|--yaml allowing the user to specify the input yaml plot file.  Heretofore the yaml file was located using the input argument -m|--model (model or experiment name), which required the file to be present in parm/[model].  That was fine for development but needs to be made more robust and user friendly.

Closes #36 