### PR TITLE
Add cleanup job

### DIFF
--- a/driver/runObsMon.sh
+++ b/driver/runObsMon.sh
@@ -79,7 +79,6 @@ export cyc=`echo ${pdate}|cut -c9-10`
 export NET=obsmon
 export MODEL=${model}
 export YAML_FILE=${yaml_file}
-export KEEPDATA="YES"
 
 #--------------------------------
 # locate and source config file

--- a/driver/runObsMon.sh
+++ b/driver/runObsMon.sh
@@ -116,7 +116,7 @@ case ${MACHINE_ID} in
 	       MODEL=${MODEL}, PDY=${PDY}, cyc=${cyc}, DATAROOT=${DATAROOT}, APRUN_PY=${APRUN_PY}, \
 	       MACHINE_ID=${MACHINE_ID}, ACCOUNT=${ACCOUNT}, JOB_QUEUE=${JOB_QUEUE}, SUB=${SUB}, \
 	       OM_LOGS=${OM_LOGS}, YAML_FILE=${YAML_FILE}, CARTOPY_DATA_DIR=${CARTOPY_DATA_DIR}, \
-	       OM_PLOTS=${OM_PLOTS}" \
+	       OM_PLOTS=${OM_PLOTS}, KEEPDATA=${KEEPDATA}" \
            -l select=1:mem=500mb -l walltime=0:05:00 -N ${jobname} ${jobfile}
       ;;
 esac

--- a/driver/runObsMon.sh
+++ b/driver/runObsMon.sh
@@ -115,8 +115,9 @@ case ${MACHINE_ID} in
       $SUB -q ${JOB_QUEUE} -A ${ACCOUNT} -o ${logfile} -e ${logfile} \
 	   -v "PYTHONPATH=${PYTHONPATH}, PATH=${PATH}, HOMEobsmon=${HOMEobsmon}, COMOUT=${COMOUT}, \
 	       MODEL=${MODEL}, PDY=${PDY}, cyc=${cyc}, DATAROOT=${DATAROOT}, APRUN_PY=${APRUN_PY}, \
-	       MACHINE_ID=${MACHINE_ID}, ACCOUNT=${ACCOUNT}, JOB_QUEUE=${JOB_QUEUE}, SUB=${SUB},
-	       OM_LOGS=${OM_LOGS}, YAML_FILE=${YAML_FILE}, CARTOPY_DATA_DIR=${CARTOPY_DATA_DIR}" \
+	       MACHINE_ID=${MACHINE_ID}, ACCOUNT=${ACCOUNT}, JOB_QUEUE=${JOB_QUEUE}, SUB=${SUB}, \
+	       OM_LOGS=${OM_LOGS}, YAML_FILE=${YAML_FILE}, CARTOPY_DATA_DIR=${CARTOPY_DATA_DIR}, \
+	       OM_PLOTS=${OM_PLOTS}" \
            -l select=1:mem=500mb -l walltime=0:05:00 -N ${jobname} ${jobfile}
       ;;
 esac

--- a/jobs/JMON_PLOT_OBS
+++ b/jobs/JMON_PLOT_OBS
@@ -49,8 +49,3 @@ status=$?
 if [[ -e "${pgmout}" ]] ; then
   cat "${pgmout}"
 fi
-
-####################
-# Remove workspace -- this will have to be a separate job that runs
-# after the OM_plot job is complete.
-####################

--- a/jobs/JMON_PLOT_OBS
+++ b/jobs/JMON_PLOT_OBS
@@ -34,7 +34,7 @@ cd ${DATA}
 ##################################
 # Remove workspace when finished
 ##################################
-KEEPDATA=${KEEPDATA:-"NO"}
+export KEEPDATA=${KEEPDATA:-"NO"}
 
 ################
 # Run exscript

--- a/modulefiles/obs-monitor/orion.lua
+++ b/modulefiles/obs-monitor/orion.lua
@@ -9,9 +9,9 @@ local pkgNameVer = myModuleFullName()
 conflict(pkgName)
 
 
-prepend_path("MODULEPATH", " /work/noaa/epic/role-epic/spack-stack/orion/spack-stack-1.6.0/envs/unified-env-rocky9/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/work/noaa/epic/role-epic/spack-stack/orion/spack-stack-1.6.0/envs/unified-env-intel-2023.2.4/install/modulefiles/Core")
 
-load ("stack-intel/2021.9.0")
+load ("stack-intel/2021.10.0")
 load ("python/3.10.8")
 
 local pyenvpath = "/work/noaa/da/esafford/noscrub/python/envs/"

--- a/parm/OM_config
+++ b/parm/OM_config
@@ -1,4 +1,6 @@
 
+export KEEPDATA=${KEEPDATA:-"NO"}
+
 readonly om_dir_root=$(cd "$(dirname "$(readlink -f -n "${BASH_SOURCE[0]}" )" )/.." && pwd -P)
 export HOMEobsmon=${om_dir_root}
 export JOBSobsmon=${om_dir_root}/jobs
@@ -62,5 +64,3 @@ export OM_LOGS="${ptmp}/logs/OM_logs"
 export OM_PLOTS="${ptmp}/OM_plots"
 export DATAROOT=${DATAROOT:-${stmp}}
 export COMOUT=${COMOUT:-${ptmp}}
-
-export KEEPDATA=${KEEPDATA:-"NO"}

--- a/parm/OM_config
+++ b/parm/OM_config
@@ -72,3 +72,5 @@ export OM_LOGS="${ptmp}/logs/OM_logs"
 export OM_PLOTS="${ptmp}/OM_plots"
 export DATAROOT=${DATAROOT:-${stmp}}
 export COMOUT=${COMOUT:-${ptmp}}
+
+export KEEPDATA=${KEEPDATA:-"NO"}

--- a/parm/OM_config
+++ b/parm/OM_config
@@ -69,5 +69,6 @@ export PROJECT=${PROJECT:-$project}
 export JOB_QUEUE=${JOB_QUEUE:-$queue}
 
 export OM_LOGS="${ptmp}/logs/OM_logs"
+export OM_PLOTS="${ptmp}/OM_plots"
 export DATAROOT=${DATAROOT:-${stmp}}
 export COMOUT=${COMOUT:-${ptmp}}

--- a/parm/OM_config
+++ b/parm/OM_config
@@ -36,8 +36,9 @@ case ${MACHINE_ID} in
       account="GFS-DEV"
       ;;
 
-   orion)
+   orion|hercules)
       export SUB="sbatch"
+      export SERVICE_PARTITION="service"
       export CARTOPY_DATA_DIR="/work/noaa/da/esafford/noscrub/python/envs/obs-mon/share/cartopy"
 
       ptmp="/work2/noaa/stmp/${USER}"
@@ -48,17 +49,6 @@ case ${MACHINE_ID} in
       account="da-cpu"
       ;;
 
-   hercules)
-      export SUB="sbatch"
-      export CARTOPY_DATA_DIR="/work/noaa/da/esafford/noscrub/python/envs/obs-mon/share/cartopy"
-
-      ptmp="/work2/noaa/stmp/${USER}"
-      stmp="/work/noaa/stmp/${USER}" 
-
-      queue=""
-      project=""
-      account="da-cpu"
-      ;;
 esac
 
 module load obs-monitor/${MACHINE_ID}

--- a/scripts/exobsmon_plot.sh
+++ b/scripts/exobsmon_plot.sh
@@ -66,7 +66,7 @@ if compgen -G "${DATA}/OM_PLOT*.yaml" > /dev/null; then
 	    ${SUB} -q $JOB_QUEUE -A $ACCOUNT -o ${logfile} -e ${logfile} \
 	        -v "PYTHONPATH=${PYTHONPATH}, PATH=${PATH}, HOMEobsmon=${HOMEobsmon}, MODEL=${MODEL}, \
 		    CNTRLobsmon=${CNTRLobsmon}, PARMobsmon=${PARMobsmon}, DATA=${DATA}, CARTOPY_DATA_DIR=${CARTOPY_DATA_DIR}, \
-		    LD_LIBRARY_PATH=${LD_LIBRARY_PATH}, cmdfile=${cmdfile}, ncpus=${ctr}" \
+		    LD_LIBRARY_PATH=${LD_LIBRARY_PATH}, cmdfile=${cmdfile}, ncpus=${ctr}, OM_PLOTS=${OM_PLOTS}" \
                 -l place=vscatter,select=1:ncpus=${ctr}:mem=${mem}gb:prepost=true,walltime=1:00:00 -N ${jobname} ${USHobsmon}/plot_wcoss2.sh
          ;;     
       esac

--- a/ush/om_cleanup.sh
+++ b/ush/om_cleanup.sh
@@ -1,22 +1,19 @@
 #!/bin/bash
 
-# om_cleanup.sh
-#
-#    1.  Sync image files with $COMOUTplots directory
-#    2.  Conditionally remove temp working space
-#
-
-echo "Begin om_cleanup.sh"; echo
-
-img_dirs=`ls -d ./*_plots/`
+# ---------------------------------------------
+# Sync image files with $COMOUTplots directory
+# 
+img_dirs=`ls -d ${DATA}/*_plots/`
 for dir in $img_dirs; do
-   echo "syncing ${DATA}/${dir} and ${COMOUTplots}/${dir}"
-   rsync -a ${DATA}/${dir} ${COMOUTplots}/${dir} 
+   echo "syncing ${dir} and ${COMOUTplots}/${dir}"
+   base_name=$(basename ${dir})
+   rsync -a ${dir} ${COMOUTplots}/${base_name} 
 done
 
-if [ ${KEEPDATA} = NO ] ; then
+# ---------------------------------------------
+# Conditionally remove temp working space
+#
+if [[ ${KEEPDATA} == "NO" ]]; then
    echo; echo "removing temp working space ${DATAROOT}/${NET}"; echo
    rm -rf ${DATAROOT}/${NET}
 fi
-
-echo "End om_cleanup.sh"; echo 

--- a/ush/om_cleanup.sh
+++ b/ush/om_cleanup.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# om_cleanup.sh
+#
+#    1.  Sync image files with $COMOUTplots directory
+#    2.  Conditionally remove temp working space
+#
+
+echo "Begin om_cleanup.sh"; echo
+
+img_dirs=`ls -d ./*_plots/`
+for dir in $img_dirs; do
+   echo "syncing ${DATA}/${dir} and ${COMOUTplots}/${dir}"
+   rsync -a ${DATA}/${dir} ${COMOUTplots}/${dir} 
+done
+
+if [ ${KEEPDATA} = NO ] ; then
+   echo; echo "removing temp working space ${DATAROOT}/${NET}"; echo
+   rm -rf ${DATAROOT}/${NET}
+fi
+
+echo "End om_cleanup.sh"; echo 

--- a/ush/plot_wcoss2.sh
+++ b/ush/plot_wcoss2.sh
@@ -23,5 +23,3 @@ module list
 if [ ! -z ${PBS_O_WORKDIR} ]; then cd ${PBS_O_WORKDIR}; fi
 
 mpiexec -np ${ncpus} --cpu-bind core cfp ${cmdfile}
-
-echo "AFTER CFP"

--- a/ush/plot_wcoss2.sh
+++ b/ush/plot_wcoss2.sh
@@ -23,3 +23,5 @@ module list
 if [ ! -z ${PBS_O_WORKDIR} ]; then cd ${PBS_O_WORKDIR}; fi
 
 mpiexec -np ${ncpus} --cpu-bind core cfp ${cmdfile}
+
+echo "AFTER CFP"


### PR DESCRIPTION
This PR adds a cleanup script which is run as a separate job following the successful completion of the plot job.  It copies the plot file directories to `$OM_PLOTS` (defined in `parm/OM_config`) and conditionally (per `$KEEPDATA` flag) removes the working directory.

I fully expect we'll need to make many changes in the output storage location and directory structure as well as add additional features to the cleanup script.  This release is an effort to set up the basic cleanup infrastructure.  This has been successfully tested on `wcoss2`, `hera`, `orion`, and `hercules`.

Close #43 