### PR TITLE
Avoid attempting to make plots which have an incomplete specification

### DIFF
--- a/ush/plotObsMon.py
+++ b/ush/plotObsMon.py
@@ -19,6 +19,7 @@ from datetime import timedelta
 
 # --------------------------------------------------------------------------------------------
 
+
 def genYaml(input_yaml, output_yaml, config):
     """
     Read in input yaml file and modify with contents of config.
@@ -182,8 +183,6 @@ if __name__ == "__main__":
                 instrument = inst.get('name')
 
                 for plot in inst.get('plot_list'):
-                    logger.info(f'plot: {plot}')
-
                     config = loadConfig(satname, instrument, obstype, plot, cycle_tm,
                                         cycle_interval, data_location, model, chan_dict)
                     plot_template = f"{config['PLOT_TEMPLATE']}.yaml"
@@ -204,11 +203,11 @@ if __name__ == "__main__":
 
                         plotData = OM_data(data_location, config, plot_yaml, logger)
                         eva(plot_yaml)
-#                       os.remove(plot_yaml)
+                        os.remove(plot_yaml)
 
                     except Exception as e:
-                        logger.info(f'Warning: unable to run genYaml() with plot_yaml file {plot_yaml} ' +
-                                    f'error: {e}')
+                        logger.info(f'Warning: unable to run genYaml() with plot_yaml file ' +
+                                    f'{plot_yaml} error: {e}')
                         continue
 
     if 'minimization' in mon_dict.keys():

--- a/ush/plotObsMon.py
+++ b/ush/plotObsMon.py
@@ -9,12 +9,15 @@ import os
 from re import sub
 import yaml
 from om_data import OM_data
+import datetime as dt
 
 from wxflow import parse_j2yaml, save_as_yaml
 from wxflow import add_to_datetime, to_timedelta, to_datetime
 from eva.eva_driver import eva
 from eva.utilities.logger import Logger
+from datetime import timedelta
 
+# --------------------------------------------------------------------------------------------
 
 def genYaml(input_yaml, output_yaml, config):
     """
@@ -179,9 +182,10 @@ if __name__ == "__main__":
                 instrument = inst.get('name')
 
                 for plot in inst.get('plot_list'):
+                    logger.info(f'plot: {plot}')
+
                     config = loadConfig(satname, instrument, obstype, plot, cycle_tm,
                                         cycle_interval, data_location, model, chan_dict)
-
                     plot_template = f"{config['PLOT_TEMPLATE']}.yaml"
                     plot_yaml = f"{config['SENSOR']}_{config['SAT']}_{plot_template}"
 
@@ -195,11 +199,17 @@ if __name__ == "__main__":
                     os.chdir(plot_dir)
 
                     config['DATA'] = plot_dir
-                    genYaml(plot_template, plot_yaml, config)
+                    try:
+                        genYaml(plot_template, plot_yaml, config)
 
-                    plotData = OM_data(data_location, config, plot_yaml, logger)
-                    eva(plot_yaml)
-                    os.remove(plot_yaml)
+                        plotData = OM_data(data_location, config, plot_yaml, logger)
+                        eva(plot_yaml)
+#                       os.remove(plot_yaml)
+
+                    except Exception as e:
+                        logger.info(f'Warning: unable to run genYaml() with plot_yaml file {plot_yaml} ' +
+                                    f'error: {e}')
+                        continue
 
     if 'minimization' in mon_dict.keys():
         satname = None

--- a/ush/splitPlotYaml.py
+++ b/ush/splitPlotYaml.py
@@ -29,38 +29,59 @@ def removeKey(d, keys):
     return r
 
 
-def check_plotlist(type, logger, plot_list, sat=None, instr=None):
+def check_plotlist(type, logger, plotlist, sat=None, instr=None, obstype=None):
     """
+    Parse plotlist for missing required elements.
+
+    Parameters:
+        type (str): type of plot
+        logger (Logger):  logger for output warnings
+        plotlist (list):  list of requested plot specifications
+        sat (str): satellite name (deafault None)
+        instr (str); instrument name (default None)
+        obstype (str): observation type namea (default None)
+
+    Return:
+        True if no required elements are missing from plotlist, else False
     """
-    logger.info(f'--> check_plotlist')
-    sat_reqs = {'rad': ['plot', 'times', 'channels', 'component', 'run'], 
-                'ozn': ['plot', 'times', 'levels', 'component', 'run']} 
+
+    sat_reqs = {'rad': ['plot', 'times', 'channels', 'component', 'run'],
+                'ozn': ['plot', 'times', 'levels', 'component', 'run']}
+    min_reqs = ['plot', 'times', 'run']
+    obs_reqs = ['plot', 'times', 'datatypes', 'run']
 
     rtn_val = True
     missing = []
     match type:
-            case 'sat':   
-                if 'rad' in plot_list.get('plot'):
-                    reqs = sat_reqs.get('rad')
-                else:
-                    reqs = sat_reqs.get('ozn')
+        case 'sat':
+            if 'rad' in plotlist.get('plot'):
+                reqs = sat_reqs.get('rad')
+            else:
+                reqs = sat_reqs.get('ozn')
 
-                for val in reqs:
-                    if val not in plot_list:
-                        missing.append(val) 
-                        plot_str = (f" {instr} {sat} {plot_list.get('plot')}")         
+            for val in reqs:
+                if val not in plotlist:
+                    missing.append(val)
+                    plot_info = (f" {instr} {sat} {plotlist.get('plot')}")
 
-#           case 'min':   
-#           case 'obs':   
-#           cast _:
+        case 'min':
+            for val in min_reqs:
+                if val not in plotlist:
+                    missing.append(val)
+                    plot_info = (f" {plotlist.get('plot')}")
+
+        case 'obs':
+            for val in obs_reqs:
+                if val not in plotlist:
+                    missing.append(val)
+                    plot_info = (f" {obstype}, {plotlist.get('plot')}")
 
     if missing:
-        logger.info(f'WARNING:  YAML for plot {plot_str}  is missing  {missing}')
+        logger.info(f'WARNING:  YAML for plot {plot_info}  is missing  {missing}')
         logger.info(f'WARNING:  Requested plot will be SKIPPED.')
         rtn_val = False
- 
+
     return (rtn_val)
-    logger.info(f'<-- check_plotlist')
 
 
 if __name__ == "__main__":
@@ -155,9 +176,10 @@ if __name__ == "__main__":
         md = removeKey(mon_dict, ['satellites', 'observations'])
         fname = f'OM_PLOT_minimization.yaml'
         mm = md.get('minimization')
-        logger.info(f'mm: {mm}')
-        for m in mm.get('plot_list'):
-            logger.info(f'm: {m}')
+
+        for pl in mm[0]['plot_list']:
+            if not check_plotlist('min', logger, pl):
+                mm[0]['plot_list'].remove(pl)
 
         file = open(fname, "w")
         yaml.dump(md, file)
@@ -165,6 +187,14 @@ if __name__ == "__main__":
 
     if 'observations' in mon_dict.keys():
         od = removeKey(mon_dict, ['satellites', 'minimization'])
+        obs = od.get('observations')
+
+        for ob in obs:
+            obstype = ob.get('obstype')
+            for pl in ob.get('plot_list'):
+                if not check_plotlist('obs', logger, pl, obstype=obstype):
+                    ob.get('plot_list').remove(pl)
+
         fname = f'OM_PLOT_observations.yaml'
         file = open(fname, "w")
         yaml.dump(od, file)

--- a/ush/splitPlotYaml.py
+++ b/ush/splitPlotYaml.py
@@ -29,6 +29,40 @@ def removeKey(d, keys):
     return r
 
 
+def check_plotlist(type, logger, plot_list, sat=None, instr=None):
+    """
+    """
+    logger.info(f'--> check_plotlist')
+    sat_reqs = {'rad': ['plot', 'times', 'channels', 'component', 'run'], 
+                'ozn': ['plot', 'times', 'levels', 'component', 'run']} 
+
+    rtn_val = True
+    missing = []
+    match type:
+            case 'sat':   
+                if 'rad' in plot_list.get('plot'):
+                    reqs = sat_reqs.get('rad')
+                else:
+                    reqs = sat_reqs.get('ozn')
+
+                for val in reqs:
+                    if val not in plot_list:
+                        missing.append(val) 
+                        plot_str = (f" {instr} {sat} {plot_list.get('plot')}")         
+
+#           case 'min':   
+#           case 'obs':   
+#           cast _:
+
+    if missing:
+        logger.info(f'WARNING:  YAML for plot {plot_str}  is missing  {missing}')
+        logger.info(f'WARNING:  Requested plot will be SKIPPED.')
+        rtn_val = False
+ 
+    return (rtn_val)
+    logger.info(f'<-- check_plotlist')
+
+
 if __name__ == "__main__":
     """
     splitPlotYaml
@@ -71,6 +105,7 @@ if __name__ == "__main__":
     data = mon_dict.get('data')
 
     if 'satellites' in mon_dict.keys():
+        logger.info(f' split_plot, in satellites')
         sd = removeKey(mon_dict, ['minimization', 'observations'])
 
         for sat in mon_dict.get('satellites'):
@@ -79,14 +114,19 @@ if __name__ == "__main__":
             for inst in sat.get('instruments'):
                 iname = inst.get('name')
                 plist = inst.get('plot_list')
+                for pl in inst.get('plot_list'):
+                    if not check_plotlist('sat', logger, pl, sat=satname, instr=iname):
+                        continue
 
                 # --------------------------------------------------------------------
                 # For instruments with a large number of channels split the plot_list
                 #
                 channels = chan_dict.get(iname)
+                logger.info(f' channels: {channels}')
                 nchans = 0
                 if channels is not None:
                     nchans = len(channels.split(","))
+                logger.info(f' nchans: {nchans}')
 
                 if nchans > 100:
                     ctr = 0
@@ -114,6 +154,11 @@ if __name__ == "__main__":
     if 'minimization' in mon_dict.keys():
         md = removeKey(mon_dict, ['satellites', 'observations'])
         fname = f'OM_PLOT_minimization.yaml'
+        mm = md.get('minimization')
+        logger.info(f'mm: {mm}')
+        for m in mm.get('plot_list'):
+            logger.info(f'm: {m}')
+
         file = open(fname, "w")
         yaml.dump(md, file)
         file.close()

--- a/ush/splitPlotYaml.py
+++ b/ush/splitPlotYaml.py
@@ -126,7 +126,6 @@ if __name__ == "__main__":
     data = mon_dict.get('data')
 
     if 'satellites' in mon_dict.keys():
-        logger.info(f' split_plot, in satellites')
         sd = removeKey(mon_dict, ['minimization', 'observations'])
 
         for sat in mon_dict.get('satellites'):
@@ -143,11 +142,9 @@ if __name__ == "__main__":
                 # For instruments with a large number of channels split the plot_list
                 #
                 channels = chan_dict.get(iname)
-                logger.info(f' channels: {channels}')
                 nchans = 0
                 if channels is not None:
                     nchans = len(channels.split(","))
-                logger.info(f' nchans: {nchans}')
 
                 if nchans > 100:
                     ctr = 0

--- a/ush/splitPlotYaml.py
+++ b/ush/splitPlotYaml.py
@@ -37,7 +37,7 @@ def check_plotlist(type, logger, plotlist, sat=None, instr=None, obstype=None):
         type (str): type of plot
         logger (Logger):  logger for output warnings
         plotlist (list):  list of requested plot specifications
-        sat (str): satellite name (deafault None)
+        sat (str): satellite name (default None)
         instr (str); instrument name (default None)
         obstype (str): observation type namea (default None)
 
@@ -76,7 +76,7 @@ def check_plotlist(type, logger, plotlist, sat=None, instr=None, obstype=None):
                     missing.append(val)
                     plot_info = (f" {obstype}, {plotlist.get('plot')}")
 
-    if missing:
+    if len(missing) > 0:
         logger.info(f'WARNING:  YAML for plot {plot_info}  is missing  {missing}')
         logger.info(f'WARNING:  Requested plot will be SKIPPED.')
         rtn_val = False


### PR DESCRIPTION
Avoid attempting to make any plots which have an incomplete specification in the top-level yaml plot file.  This is in response to problems Andrew found in testing.  Absent these changes such incomplete specifications cause a catastrophic failure of all remaining plots.  With these changes incomplete specifications are skipped over and an identifying warning message is produced.

Closes #49 