### PR TITLE
Return plot logo and tight layout to yaml template files

### DIFF
--- a/parm/templates/conTime.yaml
+++ b/parm/templates/conTime.yaml
@@ -233,13 +233,13 @@ graphics:
       figure:
         layout: [4,1]
         figure size: [20,18]
-#       tight layout:
+        tight layout:
         title: "Valid: {{ PDATE | to_YMDH }} \n ${datatype}, Global, All Levels"
         output name: line_plots/con/time/${datatype}_count.{{ PDATE | to_YMDH }}.png
-#       plot logo:
-#         which: 'noaa/nws'
-#         loc: 'upper left'
-#         subplot_orientation: 'last'
+        plot logo:
+          which: 'noaa/nws'
+          loc: 'upper left'
+          subplot_orientation: 'last'
 
       plots:
         - add_xlabel: 'Assimilated'
@@ -357,13 +357,13 @@ graphics:
       figure:
         layout: [6,1]
         figure size: [20,18]
-#       tight layout:
+        tight layout:
         title: "Valid: {{ PDATE | to_YMDH }}\n ${datatype}, Global, All Levels"
         output name: line_plots/con/time/${datatype}_bias.{{ PDATE | to_YMDH }}.png
-#       plot logo:
-#         which: 'noaa/nws'
-#         loc: 'upper left'
-#         subplot_orientation: 'last'
+        plot logo:
+          which: 'noaa/nws'
+          loc: 'upper left'
+          subplot_orientation: 'last'
 
       plots:
         - add_xlabel: 'Obs-Ges Assimilated'

--- a/parm/templates/conVert.yaml
+++ b/parm/templates/conVert.yaml
@@ -67,13 +67,13 @@ graphics:
       figure:
         layout: [2,2]
         figure size: [20,18]
-#       tight layout:
+        tight layout:
         title: "Valid: {{ PDATE | to_YMDH }} \n ${datatype}, Global"
         output name: line_plots/con/vert/${datatype}.vert.png
-#       plot logo:
-#         which: 'noaa/nws'
-#         loc: 'upper left'
-#         subplot_orientation: 'first'
+        plot logo:
+          which: 'noaa/nws'
+          loc: 'upper left'
+          subplot_orientation: 'first'
 
       plots:
         - add_xlabel: 'Assimilated'

--- a/parm/templates/minGnormFourCycle.yaml
+++ b/parm/templates/minGnormFourCycle.yaml
@@ -72,12 +72,12 @@ graphics:
     - figure:
         layout: [1,1]
         figure size: [20,18]
-#        tight layout:
+        tight layout:
         title: "Valid: {{ PDATE | to_YMDH }}"
         output name: line_plots/min/{{MODEL}}_{{RUN}}.4cycle.gnorms.png
-          #        plot logo:
-          #          which: 'noaa/nws'
-          #          loc: 'upper center'
+        plot logo:
+          which: 'noaa/nws'
+          loc: 'upper center'
 
       plots:
         - add_xlabel: 'Iteration Number'

--- a/parm/templates/minGnormOneCycle.yaml
+++ b/parm/templates/minGnormOneCycle.yaml
@@ -68,12 +68,12 @@ graphics:
     - figure:
         layout: [1,1]
         figure size: [20,18]
-#        tight layout:
+        tight layout:
         title: "Valid: {{ PDATE | to_YMDH }}"
         output name: line_plots/min/{{MODEL}}_{{RUN}}.{{ PDATE | to_YMDH }}.gnorms.png
-          #        plot logo:
-          #          which: 'noaa/nws'
-          #          loc: 'upper right'
+        plot logo:
+          which: 'noaa/nws'
+          loc: 'upper right'
 
       plots:
         - add_xlabel: 'Iteration Number'
@@ -106,12 +106,12 @@ graphics:
     - figure:
         layout: [1,1]
         figure size: [20,18]
-#        tight layout:
+        tight layout:
         title: "Valid: {{ PDATE | to_YMDH }}"
         output name: line_plots/min/{{MODEL}}_{{RUN}}.{{ PDATE | to_YMDH }}.reduction.png
-#        plot logo:
-#          which: 'noaa/nws'
-#          loc: 'upper right'
+        plot logo:
+          which: 'noaa/nws'
+          loc: 'upper right'
 
       plots:
         - add_xlabel: 'Iteration Number'

--- a/parm/templates/minSummary.yaml
+++ b/parm/templates/minSummary.yaml
@@ -37,13 +37,13 @@ graphics:
     - figure:
         layout: [3,1]
         figure size: [20,18]
-          #        tight layout:
+        tight layout:
         title: "Valid: {{ PDATE | to_YMDH }}"
         output name: line_plots/min/{{MODEL}}_{{RUN}}.summary.gnorms.png
-          #        plot logo:
-          #which: 'noaa/nws'
-          #loc: 'upper left'
-          #subplot_orientation: 'first'
+        plot logo:
+          which: 'noaa/nws'
+          loc: 'upper left'
+          subplot_orientation: 'first'
 
       plots:
         - add_xlabel: 'Cycle Time'

--- a/parm/templates/oznSummary.yaml
+++ b/parm/templates/oznSummary.yaml
@@ -180,13 +180,13 @@ graphics:
     - figure:
         layout: [3,1]
         figure size: [20,18]
-#       tight layout:
+        tight layout:
         title: "Summary Plot {{SENSOR}}_{{SAT}} \n Valid: {{ PDATE | to_YMDH }}"
         output name: line_plots/ozn/summary/{{SENSOR}}_{{SAT}}.summary.png
-#       plot logo:
-#         which: 'noaa/nws'
-#         loc: 'upper left'
-#         subplot_orientation: 'first'
+        plot logo:
+          which: 'noaa/nws'
+          loc: 'upper left'
+          subplot_orientation: 'first'
       plots:
         # Obs counts, last 4 cycles
         # -------------------------

--- a/parm/templates/oznTime.yaml
+++ b/parm/templates/oznTime.yaml
@@ -49,12 +49,12 @@ graphics:
       figure:
         layout: [1,1]
         figure size: [20,18]
-#       tight layout:
+        tight layout:
         title: "${variable}, {{SENSOR}}_{{SAT}} level ${level}  \n Valid: {{ PDATE | to_YMDH }}"
         output name: line_plots/ozn/time/{{SENSOR}}_{{SAT}}.${level}.${variable}.png
-#       plot logo:
-#         which: 'noaa/nws'
-#         loc: 'upper right'
+        plot logo:
+          which: 'noaa/nws'
+          loc: 'upper right'
 
       plots:
         - add_xlabel: 'Cycle'
@@ -83,12 +83,12 @@ graphics:
       figure:
         layout: [2,1]
         figure size: [20,18]
-#       tight layout:
+        tight layout:
         title: "obs-{{COMPONENT}} {{SENSOR}}_{{SAT}} level ${level}  \n Valid: {{ PDATE | to_YMDH }}"
         output name: line_plots/ozn/time/{{SENSOR}}_{{SAT}}.${level}.omg.png
-#       plot logo:
-#         which: 'noaa/nws'
-#         loc: 'upper right'
+        plot logo:
+          which: 'noaa/nws'
+          loc: 'upper right'
 
       plots:
         - add_xlabel: 'Cycle'

--- a/parm/templates/radAngle.yaml
+++ b/parm/templates/radAngle.yaml
@@ -140,9 +140,9 @@ graphics:
         figure size: [20,18]
         title: "${variable}, {{SENSOR}}_{{SAT}} channel ${channel}  \n Valid: {{ PDATE | to_YMDH }}"
         output name: line_plots/rad/angle/angle.{{SENSOR}}_{{SAT}}.${channel}.${variable}.png
-#       plot logo:
-#         which: 'noaa/nws'
-#         loc: 'upper left'
+        plot logo:
+          which: 'noaa/nws'
+          loc: 'upper left'
 
       plots:
 
@@ -202,9 +202,9 @@ graphics:
         figure size: [20,18]
         title: "${variable}, {{SENSOR}}_{{SAT}} channel ${channel}  \n Valid: {{ PDATE | to_YMDH }}"
         output name: line_plots/rad/angle/angle.{{SENSOR}}_{{SAT}}.${channel}.${variable}.png
-#       plot logo:
-#         which: 'noaa/nws'
-#         loc: 'upper left'
+        plot logo:
+          which: 'noaa/nws'
+          loc: 'upper left'
 
       plots:
         - add_xlabel: 'Scan Position'

--- a/parm/templates/radBcoef.yaml
+++ b/parm/templates/radBcoef.yaml
@@ -62,12 +62,12 @@ graphics:
       figure:
         layout: [1,1]
         figure size: [20,18]
-#       tight layout:
+        tight layout:
         title: "${variable}, {{SENSOR}}_{{SAT}} channel ${channel}  \n Valid: {{ PDATE | to_YMDH }}"
         output name: line_plots/rad/bcoef/bcoef.{{SENSOR}}_{{SAT}}.${channel}.${variable}.png
-#       plot logo:
-#         which: 'noaa/nws'
-#         loc: 'upper right'
+        plot logo:
+          which: 'noaa/nws'
+          loc: 'upper right'
 
       plots:
         - add_xlabel: 'Cycle'

--- a/parm/templates/radTime.yaml
+++ b/parm/templates/radTime.yaml
@@ -213,12 +213,12 @@ graphics:
       figure:
         layout: [1,1]
         figure size: [20,18]
-#       tight layout:
+        tight layout:
         title: "${variable}, {{SENSOR}}_{{SAT}} channel ${channel}  \n Valid: {{ PDATE | to_YMDH }}"
         output name: line_plots/rad/time/time.{{SENSOR}}_{{SAT}}.${channel}.${variable}.png
-#       plot logo:
-#         which: 'noaa/nws'
-#         loc: 'upper right'
+        plot logo:
+          which: 'noaa/nws'
+          loc: 'upper right'
 
       plots:
         - add_xlabel: 'Cycle'
@@ -241,12 +241,12 @@ graphics:
       figure:
         layout: [1,1]
         figure size: [20,18]
-#       tight layout:
+        tight layout:
         title: "${variable}, {{SENSOR}}_{{SAT}} channel ${channel}  \n Valid: {{ PDATE | to_YMDH }}"
         output name: line_plots/rad/time/time.{{SENSOR}}_{{SAT}}.${channel}.${variable}.png
-#       plot logo:
-#         which: 'noaa/nws'
-#         loc: 'upper right'
+        plot logo:
+          which: 'noaa/nws'
+          loc: 'upper right'
 
       plots:
         - add_xlabel: 'Cycle'
@@ -263,13 +263,13 @@ graphics:
     - figure:
         layout: [4,1]
         figure size: [20,18]
-#       tight layout:
+        tight layout:
         title: "Summary Plot {{SENSOR}}_{{SAT}} \n Valid: {{ PDATE | to_YMDH }}"
         output name: line_plots/rad/summary/summary.{{SENSOR}}_{{SAT}}.png
-#       plot logo:
-#         which: 'noaa/nws'
-#         loc: 'upper center'
-#         subplot_orientation: 'first'
+        plot logo:
+          which: 'noaa/nws'
+          loc: 'upper center'
+          subplot_orientation: 'first'
       plots:
         # Obs counts, last 4 cycles
         # -------------------------


### PR DESCRIPTION
With the addition of https://github.com/JCSDA-internal/eva/pull/213 to eva `plot logo` and `tight layout` can now be used again in the yaml template plot files.

Note that the `obs-mon` python ve needs to be updated on each machine to pull in the latest version of `eva.`  At the moment the `obs-mon` ve is located in my `noscrub` space so I can do that.  I've updated the ve on hera, which is where I tested these changes, and update the ve on wcoss2, orion, and hercules this morning.

 
Closes #51 