### PR TITLE
Update obs-monitor wcoss2 module.

### DIFF
--- a/modulefiles/obs-monitor/wcoss2.lua
+++ b/modulefiles/obs-monitor/wcoss2.lua
@@ -9,7 +9,7 @@ local pkgNameVer = myModuleFullName()
 conflict(pkgName)
 
 
-load ("python/3.10.4")
+load ("python/3.12.0")
 
 local pyenvpath = "/lfs/h2/emc/da/noscrub/edward.safford/python/envs/"
 local pyenvname = "obs-mon"
@@ -20,7 +20,7 @@ if (mode() == "load") then
   local activate_cmd = "source "..pyenvactivate
   execute{cmd=activate_cmd, modeA={"load"}}
   prepend_path("PATH", "/lfs/h2/emc/da/noscrub/edward.safford/python/envs/obs-mon/bin")
-  prepend_path("PYTHONPATH", "/lfs/h2/emc/da/noscrub/edward.safford/python/envs/obs-mon")
+  setenv("PYTHONPATH","/lfs/h2/emc/da/noscrub/edward.safford/python/envs/obs-mon/lib/python3.12/site-packages")
 
 else
   if (mode() == "unload") then


### PR DESCRIPTION
I ran into some problems updating the obs-mon ve on wcoss2 due mostly to existing issues.  These are fixed and I've updated the python version as well.  Small changes were required in the `wcoss2.lua` module to complete the ve update.

The issue that prompted this fix was that plotting logos still didn't work on wcoss2 despite the recent update to eva.  With this change and the rebuilt ve logos (and tight layout) now work on wcoss2.

Closes #53 