### PR TITLE
Add a histogram plot template

### DIFF
--- a/parm/gfs/test_hist.yaml
+++ b/parm/gfs/test_hist.yaml
@@ -1,0 +1,26 @@
+# DA Monitoring source dictionary
+
+# This is a simple script to create a radiance plot using the radHist 
+# (histogram) plot template.
+#
+# It is intended as a proof of concept and isn't an actual part of the 
+# legacy RadMon.
+#
+
+model: gfs
+cycle_interval: 6
+
+# obs-mon hera
+data: '/scratch1/NCEPDEV/da/Edward.Safford/noscrub/test_data/gfs'
+
+satellites:
+
+  - name: g18
+    instruments:
+      - name: abi
+        plot_list:
+          - plot: rad hist
+            times: 1
+            channels: 'all'
+            component: ges
+            run: gdas

--- a/parm/gfs/test_hist.yaml
+++ b/parm/gfs/test_hist.yaml
@@ -1,10 +1,10 @@
 # DA Monitoring source dictionary
 
-# This is a simple script to create a radiance plot using the radHist 
-# (histogram) plot template.
+# This is a simple script to create a histogram plot using legacy 
+# GSI-monitor radiance scan angle data.
 #
 # It is intended as a proof of concept and isn't an actual part of the 
-# legacy RadMon.
+# legacy RadMon output.
 #
 
 model: gfs

--- a/parm/templates/radHist.yaml
+++ b/parm/templates/radHist.yaml
@@ -1,0 +1,73 @@
+#
+# Generate a histogram plot of omgnbc using legacy RadMon 
+# scan angle data for the specified cycle.
+#
+# This is plot template intended as a proof of concept and isn't 
+# a part of the legacy RadMon plots.  The legacy ConMon makes 
+# histogram # plots but the process of doing so is very cumbersome 
+# and won't be made part of the obs-monitor package.  Instead
+# histograms will be employed when conventional data from JEDI
+# is made available.  Until then the legacy histogram plots will 
+# be made with the legacy GSI-monitor components.  Once JEDI data
+# becomes availble this plot template can be adapted to make the
+# desired histograms with conventional (or any other) data.
+#
+
+
+# Data read
+#-----------
+
+datasets:
+  - name: angle
+    satellite: {{SAT}}
+    sensor: {{SENSOR}}
+    type: MonDataSpace
+    control_file:
+      - {{DATA}}/angle.{{SENSOR}}_{{SAT}}.ctl
+    filenames:
+      - {{ DATA }}/angle.{{ SENSOR }}_{{ SAT }}.{{ PDATE | to_YMDH }}.ieee_d
+
+    channels: {{CHANNELS}}
+    regions: &regions 1
+    groups:
+      - name: GsiIeee
+        variables: &variables ['omgnbc']
+
+graphics:
+
+  plotting_backend: Emcpy
+  figure_list:
+
+    # Obs count plots
+    # ---------------
+    - batch figure:
+        channels: {{CHANNELS}}
+        variables: ['omgbc']
+        sensor: {{SENSOR}}
+
+      figure:
+        layout: [1,1]
+        figure size: [20,18]
+        title: "${variable}, {{SENSOR}}_{{SAT}} channel ${channel}  \n Valid: {{ PDATE | to_YMDH }}"
+        output name: hist_plots/rad/hist/hist.{{SENSOR}}_{{SAT}}.${channel}.${variable}.png
+        plot logo:
+          which: 'noaa/nws'
+          loc: 'upper right'
+
+
+      plots:
+        - add_xlabel: 'omgbc'
+          statistics:
+            fields:
+              - field_name: angle::GsiIeee::omgbc
+                channel: ${channel}
+            statistics_variables:
+            - n
+          layers:
+          - type: Histogram
+            data:
+              variable: angle::GsiIeee::omgbc
+              channel: ${channel}
+            color: 'blue'
+            bins: 100
+            alpha: 0.5        

--- a/parm/templates/radHist.yaml
+++ b/parm/templates/radHist.yaml
@@ -48,7 +48,7 @@ graphics:
       figure:
         layout: [1,1]
         figure size: [20,18]
-        title: "${variable}, {{SENSOR}}_{{SAT}} channel ${channel}  \n Valid: {{ PDATE | to_YMDH }}"
+        title: "${variable} of scan angles, {{SENSOR}}_{{SAT}} channel ${channel}  \n Valid: {{ PDATE | to_YMDH }}"
         output name: hist_plots/rad/hist/hist.{{SENSOR}}_{{SAT}}.${channel}.${variable}.png
         plot logo:
           which: 'noaa/nws'


### PR DESCRIPTION
This PR adds a yaml driver script and a template yaml to produce histogram plots as a proof of concept within obs-monitor.  These plots are not intended to immediate use.  Rather they are intended to be adapted for use primarily with conventional data once data from JEDI becomes available.  

Until JEDI data is available the intent is to continue producing histogram plots from the legacy ConMon.  See #26  for the discussion of the problems of producing histograms from legacy conventional data.

This is an example of a histogram plot of omgbc data by scan angle, produced on hera by obs-monitor using the two new yaml files:

![hist abi_g18 7 omgbc(3)](https://github.com/user-attachments/assets/088d159b-ee5a-4824-b9e0-c83575a44768)



Closes #26 