### PR TITLE
Add missing module file load on wcoss2

### DIFF
--- a/modulefiles/obs-monitor/wcoss2.lua
+++ b/modulefiles/obs-monitor/wcoss2.lua
@@ -8,7 +8,7 @@ local pkgNameVer = myModuleFullName()
 
 conflict(pkgName)
 
-
+load ("intel/19.1.3.304")
 load ("python/3.12.0")
 
 local pyenvpath = "/lfs/h2/emc/da/noscrub/edward.safford/python/envs/"


### PR DESCRIPTION
Obs-monitor failed to run on wcoss2 due to a missing module `intel.19.1.3.304.`  I did not detect this in earlier testing because my user environment (loaded at login via my `.bashrc` file) contained the necessary module, masking the problem.  D'oh! 

My tests ran to completion on wcoss2 with this change and the module loads removed from my `.bashrc` file.

Closes #59