### PR TITLE
Extend *Wrapper.jsx files to display images

### DIFF
--- a/web/ObsMon/src/MainContent.jsx
+++ b/web/ObsMon/src/MainContent.jsx
@@ -12,9 +12,9 @@ function MainContent() {
         <main className="flex-1 p-4 overflow-y-auto">
             <Routes>
                 <Route path="/" element={<Home />} />
-                <Route path="/:satellite/:instrument/summary" element={<SummaryWrapper />} />
-                <Route path="/:satellite/:instrument/time" element={<TimeSeriesWrapper />} />
-                <Route path="/:satellite/:instrument/:channelNumber" element={<ChannelWrapper />} />
+                <Route path="/:type/:satellite/:instrument/summary" element={<SummaryWrapper />} />
+                <Route path="/:type/:satellite/:instrument/time" element={<TimeSeriesWrapper />} />
+                <Route path="/:type/:satellite/:instrument/:channelNumber" element={<ChannelWrapper />} />
 
                 <Route path="/:type/:key" element={<UnifiedWrapper />} />
                 {/* Add more routes here as needed */}

--- a/web/ObsMon/src/components/ChannelWrapper.jsx
+++ b/web/ObsMon/src/components/ChannelWrapper.jsx
@@ -1,13 +1,34 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
+import { withBase } from "../utils/paths.js";
 import { ABI, AHI, AMSUA, ATMS, CrIS, IASI, MHS, SSMIS, OMI, OMPSNP, OMPSTC8 } from "../data/channels";
+import { useCycle } from "./useCycle";
 
 function ChannelWrapper() {
-    const { satellite, instrument, channelNumber } = useParams();
+    const { type, satellite, instrument, channelNumber } = useParams();
+    const [fileExists, setFileExists] = useState(null);
+    const [filePath, setFilePath] = useState("");
+    const cycle = useCycle();
 
-    // Map instrument names to channel data
     const instruments = { ABI, AHI, AMSUA, ATMS, CrIS, IASI, MHS, SSMIS, OMI, OMPSNP, OMPSTC8 };
     const instrumentData = instruments[instrument];
+
+    useEffect(() => {
+        if (satellite && instrument && channelNumber && type && cycle) {
+            const file = `pngs/${type.toLowerCase()}/${instrument.toLowerCase()}_${satellite.toLowerCase()}_chan${channelNumber}_${cycle}.png`;
+            console.log("Checking file:", file);
+            setFilePath(file);
+
+            fetch(withBase(`/utils/checkfile.php?file=${encodeURIComponent(file)}`))
+                .then(res => res.text())
+                .then(text => {
+                    setFileExists(text.trim() === "true");
+                })
+                .catch(() => {
+                    setFileExists(false);
+                });
+        }
+    }, [satellite, instrument, channelNumber, type, cycle]);
 
     if (!instrumentData) {
         return (
@@ -25,8 +46,22 @@ function ChannelWrapper() {
                 {satellite.toUpperCase()} / {instrumentData.name} Channel {channelNumber}
             </h1>
             <p>
-                This is placeholder content for <strong>{satellite.toUpperCase()} / {" "} {instrumentData.name}</strong> channel <strong>{channelNumber}</strong>.
+                This is a channel-level time-series for <strong>{satellite.toUpperCase()} / {instrumentData.name}</strong>, channel <strong>{channelNumber}</strong>.
             </p>
+
+            {fileExists === null && <p>Checking for image...</p>}
+            {fileExists === true && (
+                <img
+                    src={withBase(`/${filePath}`)}
+                    alt={`${instrument}_${satellite} channel ${channelNumber}`}
+                    className="mt-4 max-w-full border rounded shadow"
+                />
+            )}
+            {fileExists === false && (
+                <p className="text-red-600 mt-4">
+                    Image file <code>{filePath}</code> not available.
+                </p>
+            )}
         </div>
     );
 }

--- a/web/ObsMon/src/components/ConvWrapper.jsx
+++ b/web/ObsMon/src/components/ConvWrapper.jsx
@@ -1,8 +1,13 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
+import { withBase } from "../utils/paths.js";
+import { useCycle } from "./useCycle";
 
 export default function UnifiedWrapper() {
     const { type, key } = useParams();
+    const [fileExists, setFileExists] = useState(null);  // null = checking
+    const [filePath, setFilePath] = useState("");
+    const cycle = useCycle();
 
     const titleMap = {
         q: "Q Data Time Series Page",
@@ -12,16 +17,46 @@ export default function UnifiedWrapper() {
         uv: "UV Data Time Series Page"
     };
 
+    useEffect(() => {
+        if (type && key && cycle) {
+            const file = `pngs/conv/${type}${key}_count_region1_lev1.${cycle}.png`;
+            setFilePath(file);
+
+            fetch(withBase(`/utils/checkfile.php?file=${encodeURIComponent(file)}`))
+                .then(res => res.text())
+                .then(text => {
+                    setFileExists(text.trim() === "true");
+                })
+                .catch(() => {
+                    setFileExists(false);
+                });
+        }
+    }, [type, key, cycle]);
+
     return (
         <div className="p-4">
             <h2 className="text-2xl font-bold mb-2">
                 {titleMap[type] || "Unknown Data Type"}
             </h2>
             <p>
-                This is a placeholder for the time-series plot for <strong>{type?.toUpperCase()}</strong> type{" "}
+                Time-series plot, global, all levels, <strong>{type?.toUpperCase()}</strong> type{" "}
                 <strong>{key}</strong>.
             </p>
-            {/* Insert your plot component here */}
+
+            {fileExists === null && <p>Checking for image...</p>}
+            {fileExists === true && (
+
+                <img
+                    src={withBase(`/${filePath}`)}
+                    alt={`${type}${key} plot`}
+                    className="mt-4 max-w-full border rounded shadow"
+                />
+            )}
+            {fileExists === false && (
+                <p className="text-red-600 mt-4">
+                    Image file  <code>{filePath}</code>  not available.
+                </p>
+            )}
         </div>
     );
 }

--- a/web/ObsMon/src/components/OzoneBlock.jsx
+++ b/web/ObsMon/src/components/OzoneBlock.jsx
@@ -103,7 +103,7 @@ export default function OzoneBlock({
                 <div className="ml-4 mt-1">
                     <div className="mb-2">
                         <a
-                            onClick={() => navigate(`/${satKey.toLowerCase()}/${instrument}/summary`)}
+                            onClick={() => navigate(`/ozn/${satKey.toLowerCase()}/${instrument}/summary`)}
                             className="block px-2 py-1 hover:bg-gray-100 rounded cursor-pointer"
                         >
                             Summary
@@ -111,7 +111,7 @@ export default function OzoneBlock({
                     </div>
                     <div className="mb-2">
                         <a
-                            onClick={() => navigate(`/${satKey.toLowerCase()}/${instrument}/time`)}
+                            onClick={() => navigate(`/ozn/${satKey.toLowerCase()}/${instrument}/time`)}
                             className="block px-2 py-1 hover:bg-gray-100 rounded cursor-pointer"
                         >
                             Time Series

--- a/web/ObsMon/src/components/SatelliteBlock.jsx
+++ b/web/ObsMon/src/components/SatelliteBlock.jsx
@@ -141,7 +141,7 @@ export default function SatelliteBlock({
                 <div className="ml-4 mt-1">
                     <div className="mb-2">
                         <a
-                            onClick={() => navigate(`/${satKey.toLowerCase()}/${instrument}/summary`)}
+                            onClick={() => navigate(`/rad/${satKey.toLowerCase()}/${instrument}/summary`)}
                             className="block px-2 py-1 hover:bg-gray-100 rounded cursor-pointer"
                         >
                             Summary
@@ -176,7 +176,7 @@ export default function SatelliteBlock({
                             <li
                                 key={channel.id}
                                 onClick={() =>
-                                    navigate(`/${satKey.toLowerCase()}/${instrument}/${channel.id}`)
+                                    navigate(`/rad/${satKey.toLowerCase()}/${instrument}/${channel.id}`)
                                 }
                                 style={{
                                     color: getTextColor(channel),

--- a/web/ObsMon/src/components/SummaryWrapper.jsx
+++ b/web/ObsMon/src/components/SummaryWrapper.jsx
@@ -1,7 +1,29 @@
+import React, { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
+import { withBase } from "../utils/paths.js";
+import { useCycle } from "./useCycle";
 
 function SummaryWrapper() {
-    const { satellite, instrument } = useParams();
+    const { type, satellite, instrument } = useParams();
+    const [fileExists, setFileExists] = useState(null);
+    const [filePath, setFilePath] = useState("");
+    const cycle = useCycle();
+
+    useEffect(() => {
+        if (satellite && instrument && cycle && type) {
+            const file = `pngs/${type.toLowerCase()}/${instrument.toLowerCase()}_${satellite.toLowerCase()}_summary_${cycle}.png`;
+            setFilePath(file);
+
+            fetch(withBase(`/utils/checkfile.php?file=${encodeURIComponent(file)}`))
+                .then(res => res.text())
+                .then(text => {
+                    setFileExists(text.trim() === "true");
+                })
+                .catch(() => {
+                    setFileExists(false);
+                });
+        }
+    }, [satellite, instrument, type, cycle]);
 
     if (!satellite || !instrument) {
         return (
@@ -17,9 +39,23 @@ function SummaryWrapper() {
                 {satellite.toUpperCase()} / {instrument.toUpperCase()} Summary Page
             </h1>
             <p>
-                This is a placeholder summary for the instrument <strong>{satellite.toUpperCase()}</strong> / <strong>{instrument}</strong>.
-            </p >
-        </div >
+                This is a summary for <strong>{satellite.toUpperCase()}</strong> / <strong>{instrument}</strong>.
+            </p>
+
+            {fileExists === null && <p>Checking for image...<code>{filePath}</code></p>}
+            {fileExists === true && (
+                <img
+                    src={withBase(`/${filePath}`)}
+                    alt={`${satellite}_${instrument} summary`}
+                    className="mt-4 max-w-full border rounded shadow"
+                />
+            )}
+            {fileExists === false && (
+                <p className="text-red-600 mt-4">
+                    Image file <code>{filePath}</code> not available.
+                </p>
+            )}
+        </div>
     );
 }
 

--- a/web/ObsMon/src/components/TimeSeriesWrapper.jsx
+++ b/web/ObsMon/src/components/TimeSeriesWrapper.jsx
@@ -1,7 +1,29 @@
+import React, { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
+import { withBase } from "../utils/paths.js";
+import { useCycle } from "./useCycle";
 
 function TimeSeriesWrapper() {
-    const { satellite, instrument } = useParams();
+    const { type, satellite, instrument } = useParams();
+    const cycle = useCycle();
+    const [fileExists, setFileExists] = useState(null);
+
+    const file = (type && satellite && instrument && cycle)
+        ? `pngs/${type.toLowerCase()}/${instrument.toLowerCase()}_${satellite.toLowerCase()}_cnt_ts_${cycle}.png`
+        : "";
+
+    useEffect(() => {
+        if (file) {
+            fetch(withBase(`/utils/checkfile.php?file=${encodeURIComponent(file)}`))
+                .then(res => res.text())
+                .then(text => {
+                    setFileExists(text.trim() === "true");
+                })
+                .catch(() => {
+                    setFileExists(false);
+                });
+        }
+    }, [file]);
 
     if (!satellite || !instrument) {
         return (
@@ -14,12 +36,32 @@ function TimeSeriesWrapper() {
     return (
         <div className="p-4">
             <h1 className="text-2xl font-bold mb-2">
-                {satellite.toUpperCase()} / {instrument.toUpperCase()} Summary Page
+                {satellite.toUpperCase()} / {instrument.toUpperCase()} Time Series Page
             </h1>
             <p>
-                This is a placeholder time-series for the instrument <strong>{satellite.toUpperCase()}</strong> / <strong>{instrument}</strong>.
-            </p >
-        </div >
+                Type: <strong>{type.toUpperCase()}</strong>
+            </p>
+            <p>
+                Cycle: <strong>{cycle || "Loading..."}</strong>
+            </p>
+            <p>
+                This is a time-series plot for <strong>{satellite.toUpperCase()}</strong> / <strong>{instrument}</strong>.
+            </p>
+
+            {fileExists === null && <p>Checking for image... <code>{file}</code></p>}
+            {fileExists === true && (
+                <img
+                    src={withBase(`/${file}`)}
+                    alt={`${satellite}_${instrument} summary`}
+                    className="mt-4 max-w-full border rounded shadow"
+                />
+            )}
+            {fileExists === false && (
+                <p className="text-red-600 mt-4">
+                    Image file <code>{file}</code> not available.
+                </p>
+            )}
+        </div>
     );
 }
 

--- a/web/ObsMon/src/components/useCycle.js
+++ b/web/ObsMon/src/components/useCycle.js
@@ -1,0 +1,24 @@
+// src/hooks/useCycle.js
+import { useEffect, useState } from "react";
+import { withBase } from "../utils/paths";
+
+export function useCycle() {
+    const [cycle, setCycle] = useState("");
+
+    useEffect(() => {
+        fetch(withBase("/data/currentCycle.json"))
+            .then(res => res.json())
+            .then(config => {
+                if (config.cycleTime) {
+                    setCycle(config.cycleTime);
+                } else {
+                    console.error("cycleTime not found in config.json");
+                }
+            })
+            .catch((err) => {
+                console.error("Failed to load config.json:", err);
+            });
+    }, []);
+
+    return cycle;
+}


### PR DESCRIPTION
This PR adds these features/capabilities:

- image file display to *Wrapper.jsx files
- new useCycle.js hook to dynamically use cycle time in image file lookup

Notes:
- I've placed `useCycle.js` in the components directory.  It contains React code and therefore doesn't really qualify as a utility, which (I'm told by my friend) should only contain javascript code and **no** React code.  If I/we add additional such hook files it might be worth adding a `components/hooks `directory and placing them there.  For now `components` is fine in my thinking.
- The various `*Wrapper.jsx` files are similar enough that it is worth exploring combining them.  That said, I'd like to wait until we have the image file directory and naming conventions worked out.  That will have an impact on how easily the `*Wrapper.jsx` files could be combined.

You can see this in action with a **very** limited set of data.  The url is https://www.emc.ncep.noaa.gov/gmb/gdas/radiance/esafford/obsmon/index.html.  Data is available for these combinations:

- Geostationary Radiance/ABI/GOES-18/summary and channel 8
- Ozone Observations/OMPSNP/NOAA-20 summary and time series
- GPS Observations/GPS-3

All other selections should indicate that the requested file isn't found. 

Closes #67 