### PR TITLE
Fix workflow driver issues, add copy script

### DIFF
--- a/src/obs_monitor/driver/driver.py
+++ b/src/obs_monitor/driver/driver.py
@@ -329,7 +329,10 @@ def find_matching_inputs_for_times(
                 f"{dt.strftime('%Y%m%d%H')}: {archive_path}"
             )
             try:
-                dest_archive = window_dir / archive_path.name
+                time_prefix = dt.strftime("%Y%m%d%H")
+                dest_filename = f"{time_prefix}_{archive_path.name}"
+                dest_archive = window_dir / dest_filename
+
                 shutil.copy2(archive_path, dest_archive)
                 logger.info(
                     f"[{cfg.ob_type}] Copied tarball to runtime: {archive_path} -> {dest_archive}"

--- a/src/obs_monitor/driver/stubs.py
+++ b/src/obs_monitor/driver/stubs.py
@@ -146,7 +146,13 @@ def clone_schema_stub(ref_path: str | Path, out_path: str | Path, dt: datetime) 
             fv = src_var.getncattr("_FillValue")
         except Exception:
             fv = None
-        kind = src_var.dtype.kind
+
+        # Check if the dtype is the Python string class or the string 'str'
+        if src_var.dtype == str or str(src_var.dtype) == 'str':
+            kind = "S"
+        else:
+            kind = src_var.dtype.kind
+
         if fv is not None and kind in ("f", "i", "u"):
             dst_var = dst_grp.createVariable(src_var.name, src_var.dtype, src_var.dimensions, fill_value=fv, **kwargs)
         else:
@@ -166,7 +172,13 @@ def clone_schema_stub(ref_path: str | Path, out_path: str | Path, dt: datetime) 
                 if size is None:
                     size = 1
                 shape.append(size)
-        kind = var.dtype.kind
+
+        # Check if the dtype is the Python string class or the string 'str'
+        if var.dtype == str or str(var.dtype) == 'str':
+            kind = "S"
+        else:
+            kind = var.dtype.kind
+
         if kind == "f":
             # Write real NaNs for floats so plotting breaks the line at missing points
             var[:] = np.nan

--- a/ush/copy_ioda_stats.sh
+++ b/ush/copy_ioda_stats.sh
@@ -5,8 +5,8 @@
 #
 #  Copy these files: 
 #
-#     - gdas.t[HH]z.atmos_analysis.ioda_hofx_stats.tar.gz 
-#     - gdas.t[HH]z.atmos_stats.txt
+#     - ${RUN}.t[HH]z.${COMPONENT}.ioda_hofx_stats.tar.gz 
+#     - ${RUN}.t[HH]z.${COMPONENT}.txt
 #
 #  from SOURCE to TARGET preserving the source directory 
 #  structure.  
@@ -16,15 +16,18 @@
 # --------------------------------------------------------
 
 usage() {
+    echo ""
     echo "Usage: $0 [ -s | --src SOURCE_DIR ] [ -t | --target TARGET_DIR ]"
+    echo ""
+    echo "  optional parameters:   -r | --run RUN (default is gdas)"
+    echo "                         -c | --run COMPONENT (default is atmos)"
     exit 1
 }
 
-ioda_file="atmos_analysis.ioda_hofx_stats.tar.gz"
-atmos_file="atmos_stats.txt"
-
 SOURCE=""
 TARGET=""
+RUN="gdas"
+COMPONENT="atmos"
 
 # ------------------------
 # Handle input parameters
@@ -47,12 +50,28 @@ while [[ $# -gt 0 ]]; do
                 exit 1
             fi
             SOURCE="$2"; shift 2 ;;
+
 	-t|--target)
             if [[ -z "$2" || "$2" == -* ]]; then
                 echo "Error: -t|--target requires a value."
                 exit 1
             fi
             TARGET="$2"; shift 2 ;;
+
+        -r|--run)
+            if [[ -z "$2" || "$2" == -* ]]; then
+                echo "Error: -t|--target requires a value."
+                exit 1
+            fi
+            RUN="$2"; shift 2 ;;
+
+        -c|--component)
+            if [[ -z "$2" || "$2" == -* ]]; then
+                echo "Error: -t|--target requires a value."
+                exit 1
+            fi
+            COMPONENT="$2"; shift 2 ;;
+
         -h|--help)
             usage
             ;;
@@ -64,9 +83,9 @@ while [[ $# -gt 0 ]]; do
 done
 
 
-# ------------------------------------------------------
-# Confirm both parameters have been provided and parsed
-# ------------------------------------------------------
+# ----------------------------------------------------------
+# Confirm required parameters have been provided and parsed
+# ----------------------------------------------------------
 if [[ -z "$SOURCE" ]] || [[ -z "$TARGET" ]]; then
     echo "Error: Both --src and --target are required."
     usage
@@ -85,8 +104,13 @@ if [[ ! -d "$TARGET" ]]; then
 fi
 
 echo; echo "using:"
-echo "  SOURCE = $SOURCE"
-echo "  TARGET = $TARGET"; echo
+echo "  SOURCE    = $SOURCE"
+echo "  TARGET    = $TARGET"
+echo "  RUN       = $RUN"
+echo "  COMPONENT = $COMPONENT";echo
+
+ioda_file="${COMPONENT}_analysis.ioda_hofx_stats.tar.gz"
+atmos_file="${COMPONENT}_stats.txt"
 
 
 # ------------------------------------------------------------
@@ -96,9 +120,9 @@ echo "  TARGET = $TARGET"; echo
 # 2. Use sed to extract YYYYMMDD and HH from the path
 # 3. Sort and Unique to ensure each cycle is only listed once
 # ------------------------------------------------------------
-mapfile -t cycles < <(find "$TARGET" -type f \
-	\( -name "gdas.t[0-9][0-9]z.${ioda_file}" \) \
-    | sed -n 's/.*gdas\.\([0-9]\{8\}\)\/\([0-9]\{2\}\).*/\1\2/p' \
+mapfile -t cycles < <(find "${TARGET}" -type f \
+    \( -name "${RUN}.t[0-9][0-9]z.${ioda_file}" \) \
+    | sed -n "s/.*${RUN}\.\([0-9]\{8\}\)\/\([0-9]\{2\}\).*/\1\2/p" \
     | sort -u)
 
 if [[ ${#cycles[@]} -eq 0 ]]; then
@@ -113,17 +137,17 @@ echo; echo "latest cycle in TARGET: $LAST_TARGET_CYCLE"; echo
 # -----------------------------------------------------
 # In source directory get an array of available cycles 
 # -----------------------------------------------------
-mapfile -t cycles < <(find "$SOURCE" -type f \
-    \( -name "gdas.t[0-9][0-9]z.${ioda_file}" \
-    -o -name "gdas.t[0-9][0-9]z.${atmos_file}" \) \
-    | sed -n 's/.*gdas\.\([0-9]\{8\}\)\/\([0-9]\{2\}\).*/\1\2/p' \
+mapfile -t cycles < <(find "${SOURCE}" -type f \
+    \( -name "${RUN}.t[0-9][0-9]z.${ioda_file}" \
+    -o -name "${RUN}.t[0-9][0-9]z.${atmos_file}" \) \
+    | sed -n "s/.*${RUN}\.\([0-9]\{8\}\)\/\([0-9]\{2\}\).*/\1\2/p" \
     | sort -u)
 
 if [[ ${#cycles[@]} -eq 0 ]]; then
     echo "No matching files found. Check your SOURCE or file patterns."
 
 else
-    SOURCE_CYCLE_TIME=$(echo "$PATH_VAR" | sed -n 's/.*gdas\.\([0-9]\{8\}\)\/\([0-9]\{2\}\).*/\1\2/p')
+    SOURCE_CYCLE_TIME=$(echo "$PATH_VAR" | sed -n 's/.*${RUN}\.\([0-9]\{8\}\)\/\([0-9]\{2\}\).*/\1\2/p')
     echo "$SOURCE_CYCLE_TIME"
 
 fi
@@ -138,7 +162,7 @@ for cycle in "${cycles[@]}"; do
         hh="${cycle:8:2}"
         
         # Define the base directory for this cycle
-        cycle_base="gdas.${ymd}/${hh}"
+        cycle_base="${RUN}.${ymd}/${hh}"
 
 	#-------------------------------------------------------------
         # Find the specific files we want within this cycle's folder.
@@ -149,8 +173,8 @@ for cycle in "${cycles[@]}"; do
 	#-------------------------------------------------------------
 	
 	find "${SOURCE}/${cycle_base}" -type f \( \
-            -name "gdas.t${hh}z.${ioda_file}" -o \
-            -name "gdas.t${hh}z.${atmos_file}" \
+            -name "${RUN}.t${hh}z.${ioda_file}" -o \
+            -name "${RUN}.t${hh}z.${atmos_file}" \
         \) -mmin +10 -size +0c | while read -r full_src_path; do
 
             # -------------------------------------
@@ -158,10 +182,10 @@ for cycle in "${cycles[@]}"; do
             # -------------------------------------
             rel_file_path="${full_src_path#$SOURCE/}"
            
-	    # ----------------------------------------------- 
+	    # ------------------------------------------------------- 
             # Get the directory portion of the relative path
-            # e.g., gdas.20260224/06/products/atmos/anlmon
-	    # ----------------------------------------------- 
+            # e.g., ${RUN}.20260224/06/products/${COMPNONENT}/anlmon
+	    # ------------------------------------------------------- 
             rel_dir_path=$(dirname "${rel_file_path}")
 
 	    # --------------------------------------

--- a/ush/copy_ioda_stats.sh
+++ b/ush/copy_ioda_stats.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-# -------------------------------------------------------
+# --------------------------------------------------------
 #  copy_ioda_stats.sh
 #
 #  Copy these files: 
 #
-#     - gdas.t[HH]z.atmos_analysis.ioda_stats.tar.gz 
+#     - gdas.t[HH]z.atmos_analysis.ioda_hofx_stats.tar.gz 
 #     - gdas.t[HH]z.atmos_stats.txt
 #
 #  from SOURCE to TARGET preserving the source directory 
@@ -13,7 +13,7 @@
 #
 #  Only copy files that are non-zero sized and older 
 #  than 10 minutes to avoid copying partial files.
-# -------------------------------------------------------
+# --------------------------------------------------------
 
 usage() {
     echo "Usage: $0 [ -s | --src SOURCE_DIR ] [ -t | --target TARGET_DIR ]"
@@ -59,7 +59,6 @@ while [[ $# -gt 0 ]]; do
         *)
             echo "Unknown: $1"; 
             usage
-	    exit 1
 	    ;;
     esac
 done
@@ -81,7 +80,7 @@ if [[ ! -d "$SOURCE" ]]; then
    exit 2
 fi
 if [[ ! -d "$TARGET" ]]; then
-   echo "Source $TARGET is not a valid directory"
+   echo "Target $TARGET is not a valid directory"
    exit 2
 fi
 
@@ -106,7 +105,6 @@ if [[ ${#cycles[@]} -eq 0 ]]; then
     echo "WARNING:  No cycle times found in TARGET directory. Assuming TARGET directory is new/empty"
     LAST_TARGET_CYCLE=0
 else
-    CYCLE_TIME=$(echo "$PATH_VAR" | sed -n 's/.*gdas\.\([0-9]\{8\}\)\/\([0-9]\{2\}\).*/\1\2/p')
     LAST_TARGET_CYCLE="${cycles[-1]}"
 fi
 

--- a/ush/copy_ioda_stats.sh
+++ b/ush/copy_ioda_stats.sh
@@ -1,0 +1,185 @@
+#!/bin/bash
+
+# -------------------------------------------------------
+#  copy_ioda_stats.sh
+#
+#  Copy these files: 
+#
+#     - gdas.t[HH]z.atmos_analysis.ioda_stats.tar.gz 
+#     - gdas.t[HH]z.atmos_stats.txt
+#
+#  from SOURCE to TARGET preserving the source directory 
+#  structure.  
+#
+#  Only copy files that are non-zero sized and older 
+#  than 10 minutes to avoid copying partial files.
+# -------------------------------------------------------
+
+usage() {
+    echo "Usage: $0 [ -s | --src SOURCE_DIR ] [ -t | --target TARGET_DIR ]"
+    exit 1
+}
+
+ioda_file="atmos_analysis.ioda_hofx_stats.tar.gz"
+atmos_file="atmos_stats.txt"
+
+SOURCE=""
+TARGET=""
+
+# ------------------------
+# Handle input parameters
+# ------------------------
+while [[ $# -gt 0 ]]; do
+    # --------------------------------------------------------------------
+    # If an arg contains '=', split it into two separate args ($1 and $2)
+    # --------------------------------------------------------------------
+    if [[ "$1" == "--"*=* ]]; then
+        arg="${1%%=*}"
+        val="${1#*=}"
+        shift
+        set -- "$arg" "$val" "$@"
+    fi
+
+    case $1 in
+        -s|--src)
+	    if [[ -z "$2" || "$2" == -* ]]; then
+                echo "Error: -s|--src requires a value."
+                exit 1
+            fi
+            SOURCE="$2"; shift 2 ;;
+	-t|--target)
+            if [[ -z "$2" || "$2" == -* ]]; then
+                echo "Error: -t|--target requires a value."
+                exit 1
+            fi
+            TARGET="$2"; shift 2 ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            echo "Unknown: $1"; 
+            usage
+	    exit 1
+	    ;;
+    esac
+done
+
+
+# ------------------------------------------------------
+# Confirm both parameters have been provided and parsed
+# ------------------------------------------------------
+if [[ -z "$SOURCE" ]] || [[ -z "$TARGET" ]]; then
+    echo "Error: Both --src and --target are required."
+    usage
+fi
+
+# ------------------------------------------------
+# Perform sanity check for both source and target
+# ------------------------------------------------
+if [[ ! -d "$SOURCE" ]]; then
+   echo "Source $SOURCE is not a valid directory"
+   exit 2
+fi
+if [[ ! -d "$TARGET" ]]; then
+   echo "Source $TARGET is not a valid directory"
+   exit 2
+fi
+
+echo; echo "using:"
+echo "  SOURCE = $SOURCE"
+echo "  TARGET = $TARGET"; echo
+
+
+# ------------------------------------------------------------
+# Determine the latest cycle time in target directory
+#
+# 1. Find files matching $ioda_file
+# 2. Use sed to extract YYYYMMDD and HH from the path
+# 3. Sort and Unique to ensure each cycle is only listed once
+# ------------------------------------------------------------
+mapfile -t cycles < <(find "$TARGET" -type f \
+	\( -name "gdas.t[0-9][0-9]z.${ioda_file}" \) \
+    | sed -n 's/.*gdas\.\([0-9]\{8\}\)\/\([0-9]\{2\}\).*/\1\2/p' \
+    | sort -u)
+
+if [[ ${#cycles[@]} -eq 0 ]]; then
+    echo "WARNING:  No cycle times found in TARGET directory. Assuming TARGET directory is new/empty"
+    LAST_TARGET_CYCLE=0
+else
+    CYCLE_TIME=$(echo "$PATH_VAR" | sed -n 's/.*gdas\.\([0-9]\{8\}\)\/\([0-9]\{2\}\).*/\1\2/p')
+    LAST_TARGET_CYCLE="${cycles[-1]}"
+fi
+
+echo; echo "latest cycle in TARGET: $LAST_TARGET_CYCLE"; echo
+
+# -----------------------------------------------------
+# In source directory get an array of available cycles 
+# -----------------------------------------------------
+mapfile -t cycles < <(find "$SOURCE" -type f \
+    \( -name "gdas.t[0-9][0-9]z.${ioda_file}" \
+    -o -name "gdas.t[0-9][0-9]z.${atmos_file}" \) \
+    | sed -n 's/.*gdas\.\([0-9]\{8\}\)\/\([0-9]\{2\}\).*/\1\2/p' \
+    | sort -u)
+
+if [[ ${#cycles[@]} -eq 0 ]]; then
+    echo "No matching files found. Check your SOURCE or file patterns."
+
+else
+    SOURCE_CYCLE_TIME=$(echo "$PATH_VAR" | sed -n 's/.*gdas\.\([0-9]\{8\}\)\/\([0-9]\{2\}\).*/\1\2/p')
+    echo "$SOURCE_CYCLE_TIME"
+
+fi
+
+# -------------------------------------------------------------------
+# Determine which available cycles are newer than $LAST_TARGET_CYCLE
+# -------------------------------------------------------------------
+for cycle in "${cycles[@]}"; do
+
+    if [[ ${cycle} -gt ${LAST_TARGET_CYCLE} ]]; then
+        ymd="${cycle:0:8}"
+        hh="${cycle:8:2}"
+        
+        # Define the base directory for this cycle
+        cycle_base="gdas.${ymd}/${hh}"
+
+	#-------------------------------------------------------------
+        # Find the specific files we want within this cycle's folder.
+	#
+        # Using 'find' inside the loop to get the FULL relative path
+	# with included checks to avoid copying zero-sized files and 
+	# those less than 10 min old.
+	#-------------------------------------------------------------
+	
+	find "${SOURCE}/${cycle_base}" -type f \( \
+            -name "gdas.t${hh}z.${ioda_file}" -o \
+            -name "gdas.t${hh}z.${atmos_file}" \
+        \) -mmin +10 -size +0c | while read -r full_src_path; do
+
+            # -------------------------------------
+            # Get the path relative to $SOURCE
+            # -------------------------------------
+            rel_file_path="${full_src_path#$SOURCE/}"
+           
+	    # ----------------------------------------------- 
+            # Get the directory portion of the relative path
+            # e.g., gdas.20260224/06/products/atmos/anlmon
+	    # ----------------------------------------------- 
+            rel_dir_path=$(dirname "${rel_file_path}")
+
+	    # --------------------------------------
+            # Create the target directory structure
+	    # --------------------------------------
+            mkdir -p "${TARGET}/${rel_dir_path}"
+
+	    # --------------
+            # Copy the file
+	    # --------------
+	    echo; echo "copying files for cycle ${cycle}"
+            cp -v "${full_src_path}" "${TARGET}/${rel_file_path}"
+        done
+
+    fi
+
+done
+
+exit


### PR DESCRIPTION
This PR fixes 2 problems associated with the workflow driver and adds a utility copy script. 

1. **driver.py**:  The hofx tarballs copied into the runtime workspace do not include the cycle time in their name, just the cycle hour.  So only 4 cycles could be copied before they began overwriting themselves.  The change here adds the full cycle time as a prefix to the tarball filename to ensure none of the tarballs are overwritten.
2. **stubs.py**:  The process of creating a stub structure for missing files went pear-shaped when attempting to add a variable of type string.  I added a pre-check for variables of type string before trying to access the .kind attribute as a fix.
3. **copy_ioda_stats.sh**:  A simple bash script to copy all available hofx tarballs from a source to a target directory.  I've been using this to collect output from Russ' prjedi parallel.