### PR TITLE
Add a cron start/stop script to users' EXPDIR

### DIFF
--- a/dev/workflow/generate_workflow_xml.py
+++ b/dev/workflow/generate_workflow_xml.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import argparse
 import sys
+import os
+import stat
 from pathlib import Path
 from typing import Any, Dict
 from datetime import datetime
@@ -262,6 +264,18 @@ def main() -> None:
 
     print(f"Rocoto workflow written to {output_path}")
 
+    # Customize and output setup_cron.sh
+    setup_output_path = expdir / f"setup_cron.sh"
+
+    setup_template = env.get_template("parm/setup_cron.sh.j2")
+    setup_output = setup_template.render(**render_kwargs)
+
+    setup_output_path.parent.mkdir(parents=True, exist_ok=True)
+    with setup_output_path.open("w") as f:
+        f.write(setup_output)
+        os.chmod(setup_output_path, os.stat(setup_output_path).st_mode | stat.S_IXUSR)
+
+    print(f"Setup_cron.sh script written to {setup_output_path}")
 
 if __name__ == "__main__":
     try:

--- a/parm/setup_cron.sh.j2
+++ b/parm/setup_cron.sh.j2
@@ -1,0 +1,19 @@
+#!/bin/bash
+PSLOT={{ PSLOT }}
+
+EXP_DIR={{ EXPDIR }}
+WORKFLOW_XML="${EXP_DIR}/${PSLOT}_obsmon_rocoto.xml"
+DB_FILE="${EXP_DIR}/${PSLOT}_obsmon_rocoto.db"
+
+CRON_ENTRY="*/5 * * * * $(which rocotorun) -w $WORKFLOW_XML -d $DB_FILE"
+
+case $1 in
+   add)
+      (crontab -l | grep -v "$WORKFLOW_XML"; echo "$CRON_ENTRY") | crontab -
+      echo "Cron added for $EXP_DIR"
+      ;;
+   remove)
+      crontab -l | grep -v "$WORKFLOW_XML" | crontab -
+      echo "Cron removed for $EXP_DIR"
+      ;;
+esac

--- a/parm/setup_cron.sh.j2
+++ b/parm/setup_cron.sh.j2
@@ -1,19 +1,58 @@
 #!/bin/bash
-PSLOT={{ PSLOT }}
+PSLOT="{{ PSLOT }}"
 
-EXP_DIR={{ EXPDIR }}
+EXP_DIR="{{ EXPDIR }} "
 WORKFLOW_XML="${EXP_DIR}/${PSLOT}_obsmon_rocoto.xml"
 DB_FILE="${EXP_DIR}/${PSLOT}_obsmon_rocoto.db"
 
-CRON_ENTRY="*/5 * * * * $(which rocotorun) -w $WORKFLOW_XML -d $DB_FILE"
+ROCOTO_BIN=$(which rocotorun)
+if [ -z "$ROCOTO_BIN" ]; then
+    echo "Error: rocotorun not found in PATH."
+    exit 1
+fi
+
+CRON_ENTRY="*/5 * * * * $ROCOTO_BIN -w $WORKFLOW_XML -d $DB_FILE"
+TMP_CRON="/tmp/cron_backup_$(date +%s)"
+
+# Function to clean up temp file on exit
+cleanup() {
+    rm -f "$TMP_CRON"
+}
+trap cleanup EXIT
 
 case $1 in
-   add)
-      (crontab -l | grep -v "$WORKFLOW_XML"; echo "$CRON_ENTRY") | crontab -
-      echo "Cron added for $EXP_DIR"
-      ;;
-   remove)
-      crontab -l | grep -v "$WORKFLOW_XML" | crontab -
-      echo "Cron removed for $EXP_DIR"
-      ;;
+    add|remove)
+        # 1. Attempt to list current crontab. 
+        # Note: 'crontab -l' returns error code 1 if the crontab is empty.
+        # We redirect stderr to dev null to ignore the "no crontab for user" message.
+        if ! crontab -l > "$TMP_CRON" 2>/dev/null; then
+            # If it failed and the file is NOT empty, a real error occurred.
+            if [ -s "$TMP_CRON" ]; then
+                echo "Error: Failed to access crontab safely. Exiting without changes."
+                exit 1
+            fi
+            # Otherwise, the crontab is just empty (new user), which is fine.
+            touch "$TMP_CRON"
+        fi
+
+        # 2. Modify the temporary file
+        if [ "$1" == "add" ]; then
+            (grep -v "$WORKFLOW_XML" "$TMP_CRON"; echo "$CRON_ENTRY") > "${TMP_CRON}.new"
+        else
+            grep -v "$WORKFLOW_XML" "$TMP_CRON" > "${TMP_CRON}.new"
+        fi
+
+        # 3. Load the new crontab back in
+        if crontab "${TMP_CRON}.new"; then
+            echo "Cron $1 successfully for $EXP_DIR"
+            rm -f "${TMP_CRON}.new"
+        else
+            echo "Error: Failed to update crontab. No changes were made."
+            exit 1
+        fi
+        ;;
+    *)
+        echo "Usage: $0 {add|remove}"
+        exit 1
+        ;;
 esac


### PR DESCRIPTION
Expand `generate_workflow_xml.py` to add a `setup_cron.sh` script to the user's resulting `$EXPDIR`.  This will add or remove the necessary rocoto entry to the user's crontab to drive or halt the workflow.   The arguments are straightforward:

`> ./setup_cron.sh add`
`> ../setup_cron.sh remove`


Closes #109